### PR TITLE
Add login flag to tundler API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ providers:
 
 - `debug` enables verbose logging and may also be set with `-d/--debug`.
 - `providers.<name>.locations` restricts the random locations used when `location` is omitted in API calls.
+- `login` automatically authenticates a comma-separated list of providers at startup (`all` for every provider).
 
 ## REST API
 
@@ -59,7 +60,7 @@ providers:
 | `/`           | GET    | –                                 | List providers and login state          |
 | `/connect`    | POST   | `location`, `provider` *(optional)* | Connect to a new location or provider   |
 | `/disconnect` | POST   | –                                 | Tear down the current tunnel            |
-| `/login`      | POST   | `provider` *(optional)*           | Login one provider or all when omitted  |
+| `/login`      | POST   | `providers` *(optional)*          | Login comma-separated providers or all when omitted |
 | `/logout`     | POST   | `provider` *(optional)*           | Logout one provider or all when omitted |
 | `/status`     | GET    | –                                 | Return tunnel state, IP and provider in use |
 


### PR DESCRIPTION
## Summary
- allow selecting providers to login at startup via `-login`
- update `/login` to accept `providers` query parameter
- document login option in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6869ab88c524833082c49efb6e0ca523