### PR TITLE
Implement async connect for Mullvad

### DIFF
--- a/internal/provider/mullvad/mullvad.go
+++ b/internal/provider/mullvad/mullvad.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/laurentpellegrino/tundler/internal/provider"
 	"github.com/laurentpellegrino/tundler/internal/shared"
@@ -31,11 +32,37 @@ func (m Mullvad) ActiveLocation(ctx context.Context) string {
 }
 
 func (m Mullvad) Connect(ctx context.Context, location string) provider.Status {
+	// 1. set the desired location if provided
 	if location != "" {
 		quiet(ctx, "relay", "set", "location", location)
 	}
-	quiet(ctx, "connect", "--wait")
-	return m.Status(ctx)
+
+	// 2. start the connection asynchronously
+	_ = shared.RunAsync(ctx, bin, "connect")
+
+	// 3. wait for the tunnel to be ready (or ctx/timeout is hit)
+	const (
+		pollEvery = 250 * time.Millisecond // how often to poll
+		maxWait   = 30 * time.Second       // safety cap
+	)
+	waitCtx, cancel := context.WithTimeout(ctx, maxWait)
+	defer cancel()
+
+	ticker := time.NewTicker(pollEvery)
+	defer ticker.Stop()
+
+	for {
+		st := m.Status(ctx)
+		if st.Connected && st.IP != "" {
+			return st
+		}
+
+		select {
+		case <-waitCtx.Done():
+			return st
+		case <-ticker.C:
+		}
+	}
 }
 
 func (m Mullvad) Connected(ctx context.Context) bool {


### PR DESCRIPTION
## Summary
- run `mullvad connect` asynchronously
- poll status with timeout to avoid hanging HTTP handler

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a98787cf88330a777ce1891059d56