### PR TITLE
Add locations listing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ providers:
 | `/login`      | POST   | `providers` *(optional)*          | Login comma-separated providers or all when omitted |
 | `/logout`     | POST   | `provider` *(optional)*           | Logout one provider or all when omitted |
 | `/status`     | GET    | –                                 | Return tunnel state, IP and provider in use |
+| `/locations`  | GET    | –                                 | List supported locations per logged-in provider |
 
 ## Extending Tundler
 

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -17,6 +17,10 @@ func Router(mgr *manager.Manager) *http.ServeMux {
 		writeJSON(w, mgr.List(r.Context()))
 	})
 
+	mux.HandleFunc("/locations", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, mgr.Locations(r.Context()))
+	})
+
 	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
 		provs := r.URL.Query().Get("providers")
 		if provs == "" {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"math/rand"
+	"sort"
 	"time"
 
 	"github.com/laurentpellegrino/tundler/internal/provider"
@@ -81,6 +82,21 @@ func (m *Manager) Disconnect(ctx context.Context) error {
 func (m *Manager) List(ctx context.Context) map[string]any {
 	shared.Debugf("[manager] list providers")
 	return map[string]any{"providers": m.providerInfos(ctx)}
+}
+
+// Locations returns every provider with its supported locations sorted
+// lexicographically.
+func (m *Manager) Locations(ctx context.Context) map[string][]string {
+	shared.Debugf("[manager] list locations")
+	names := m.loggedInProviders(ctx)
+	out := make(map[string][]string, len(names))
+	for _, name := range names {
+		p := m.providers[name]
+		locs := append([]string(nil), p.Locations(ctx)...)
+		sort.Strings(locs)
+		out[name] = locs
+	}
+	return out
 }
 
 // Login authenticates one provider (name ≠ "") or all providers (name == "").

--- a/internal/provider/mullvad/mullvad.go
+++ b/internal/provider/mullvad/mullvad.go
@@ -79,14 +79,19 @@ func (m Mullvad) Locations(ctx context.Context) []string {
 	out, _ := shared.RunCmd(ctx, bin, "relay", "list")
 	var cc []string
 	for _, ln := range strings.Split(out, "\n") {
-		ln = strings.TrimSpace(ln)
-		if strings.Contains(ln, "(") && strings.Contains(ln, ")") && !strings.HasPrefix(ln, "\t") {
-			start := strings.Index(ln, "(")
-			end := strings.Index(ln, ")")
-			if start >= 0 && end > start {
-				cc = append(cc, strings.TrimSpace(ln[start+1:end]))
-			}
+		if strings.HasPrefix(ln, "\t") || strings.HasPrefix(ln, " ") {
+			continue // skip server entries
 		}
+		line := strings.TrimSpace(ln)
+		if line == "" || !strings.Contains(line, "(") || !strings.Contains(line, ")") {
+			continue
+		}
+		start := strings.Index(line, "(")
+		end := strings.Index(line[start+1:], ")")
+		if end < 0 {
+			continue
+		}
+		cc = append(cc, strings.TrimSpace(line[start+1:start+1+end]))
 	}
 	return cc
 }


### PR DESCRIPTION
## Summary
- add `Manager.Locations` to get available locations from each provider
- expose `/locations` endpoint in the HTTP router
- document `/locations` in the README
- call Locations only for logged in providers
- fix mullvad location parsing to extract country codes correctly

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686aad119db08330b222dea0a9e2e5da